### PR TITLE
parallelize the built-in trajectory interpolation of each sequence in odom benchmark

### DIFF
--- a/pyboreas/eval/README.md
+++ b/pyboreas/eval/README.md
@@ -32,12 +32,14 @@ python eval/odometry_benchmark.py -h
 usage: odometry_benchmark.py [-h] [--pred PRED] [--gt GT] [--radar] [--no-interp] [--no-solver]
 
 optional arguments:
-  -h, --help       show this help message and exit
-  --pred PRED      path to prediction files
-  --gt GT          path to groundtruth files
-  --radar          evaluate radar odometry in SE(2)
-  --interp INTERP  path to interpolation output, do not set if evaluating
-  --no-solver      disable solver for built-in interpolation
+  -h, --help            show this help message and exit
+  --pred PRED           path to prediction files
+  --gt GT               path to groundtruth files
+  --radar               evaluate radar odometry in SE(2)
+  --interp INTERP       path to interpolation output, do not set if evaluating
+  --processes PROCESSES
+                        number of workers to use for built-in interpolation
+  --no-solver           disable solver for built-in interpolation
 ```
 The `pred` argument is the directory containing the odometry sequence files, which is `pyboreas/test/demo/pred/3d/` for this demo. 
 
@@ -47,11 +49,13 @@ The `radar` argument should be included to evaluate the 2D benchmark. The 3D ben
 
 The `interp` argument should be set as the output directory for the interpolation files. Setting this argument will change the operation of the benchmark script to interpolation mode, i.e., it will not compute the errors and output error results. Instead, it will output a `.txt` file for each of your odometry sequences interpolated at the groundtruth (lidar) timestamps. Use this argument only if you need to interpolate.
 
+The `processes` argument sets the number of processes to use when interpolating. Setting this argument to 1 will result in no additional subprocesses being created. Default value is the CPU count of your machine.
+
 The `no-solver` argument should be included to disable the solver for the built-in interpolation method. We use a batch optimization routine to solve for velocity estimates of each frame in order to interpolate. If the solver is disabled, the script instead interpolates with velocities approximated with finite difference. This is less accurate, but will run much faster. Suggested use is for debugging.
 
 This demo requires the built-in interpolation method. We will interpolate without the solver just for demonstration purposes (run it faster):
 ```
-python eval/odometry_benchmark.py --pred test/demo/pred/3d/ --gt test/demo/gt/ --interp test/demo/pred/3d/interp/ --no-solver
+python eval/odometry_benchmark.py --pred test/demo/pred/3d/ --gt test/demo/gt/ --interp test/demo/pred/3d/interp/ --processes 1 --no-solver
 
 interpolating sequence boreas-2021-08-05-13-34.txt ...
 boreas-2021-08-05-13-34.txt took 9.404045581817627  seconds

--- a/pyboreas/eval/odometry_benchmark.py
+++ b/pyboreas/eval/odometry_benchmark.py
@@ -11,6 +11,7 @@ if __name__ == '__main__':
     parser.add_argument('--radar', dest='radar', action='store_true', help='evaluate radar odometry in SE(2)')
     parser.set_defaults(radar=False)
     parser.add_argument('--interp', default='', type=str, help='path to interpolation output, do not set if evaluating')
+    parser.add_argument('--processes', default=os.cpu_count(), type=int, help='number of workers to use for built-in interpolation')
     parser.add_argument('--no-solver', dest='solver', action='store_false', help='disable solver for built-in interpolation')
     parser.set_defaults(solver=True)
     args = parser.parse_args()
@@ -35,7 +36,7 @@ if __name__ == '__main__':
             os.mkdir(args.interp)
 
         # interpolate
-        compute_interpolation(T_pred, times_gt, times_pred, seq_lens_gt, seq_lens_pred, seq, args.interp, args.solver)
+        compute_interpolation(T_pred, times_gt, times_pred, seq_lens_gt, seq_lens_pred, seq, args.interp, args.solver, args.processes)
     else:
         # compute errors
         t_err, r_err, _ = compute_kitti_metrics(T_gt, T_pred, seq_lens_gt, seq_lens_pred, seq, args.pred, dim, crop)

--- a/pyboreas/eval/odometry_benchmark.py
+++ b/pyboreas/eval/odometry_benchmark.py
@@ -1,7 +1,7 @@
 import argparse
 import os
 from pyboreas.utils.odometry import get_sequences, get_sequence_poses, get_sequence_poses_gt, \
-    compute_kitti_metrics, compute_interpolation
+    compute_kitti_metrics, compute_interpolation, get_sequence_times_gt
 
 if __name__ == '__main__':
     # parse arguments
@@ -24,12 +24,14 @@ if __name__ == '__main__':
     # parse sequences
     seq = get_sequences(args.pred, '.txt')
     T_pred, times_pred, seq_lens_pred = get_sequence_poses(args.pred, seq)
-    T_gt, times_gt, seq_lens_gt, crop = get_sequence_poses_gt(args.gt, seq, dim)
 
     if args.interp:     # if we are interpolating...
         # can't be the same as pred
         if args.interp == args.pred:
             raise ValueError('`interp` directory path cannot be the same as the `pred` directory path')
+
+        # get corresponding groundtruth times
+        times_gt, seq_lens_gt, _ = get_sequence_times_gt(args.gt, seq)
 
         # make interp directory if it doesn't exist
         if not os.path.exists(args.interp):
@@ -38,6 +40,9 @@ if __name__ == '__main__':
         # interpolate
         compute_interpolation(T_pred, times_gt, times_pred, seq_lens_gt, seq_lens_pred, seq, args.interp, args.solver, args.processes)
     else:
+        # get corresponding groundtruth poses
+        T_gt, _, seq_lens_gt, crop = get_sequence_poses_gt(args.gt, seq, dim)
+
         # compute errors
         t_err, r_err, _ = compute_kitti_metrics(T_gt, T_pred, seq_lens_gt, seq_lens_pred, seq, args.pred, dim, crop)
 

--- a/pyboreas/test/test_odometry.py
+++ b/pyboreas/test/test_odometry.py
@@ -73,6 +73,7 @@ class OdometryTestCase(unittest.TestCase):
         dim = 3
         interp = 'pyboreas/test/demo/pred/3d/interptest'
         solver = False
+        processes = 2
 
         # make interp directory if it doesn't exist
         if not os.path.exists(interp):
@@ -84,7 +85,7 @@ class OdometryTestCase(unittest.TestCase):
         T_gt, times_gt, seq_lens_gt, crop = get_sequence_poses_gt(gt, seq, dim)
 
         # interpolate
-        compute_interpolation(T_pred, times_gt, times_pred, seq_lens_gt, seq_lens_pred, seq, interp, solver)
+        compute_interpolation(T_pred, times_gt, times_pred, seq_lens_gt, seq_lens_pred, seq, interp, solver, processes)
 
         # read in interpolated sequences
         T_pred, times_pred, seq_lens_pred = get_sequence_poses(interp, seq)


### PR DESCRIPTION
- added a flag `processes` to specify the number of workers to use. when equal to 1, no subprocess is created.