### PR TITLE
sensors field was not previously loaded or parsed correctly

### DIFF
--- a/pyboreas/eval/submission_checker.py
+++ b/pyboreas/eval/submission_checker.py
@@ -23,6 +23,7 @@ def check_yaml(yml):
         "year",
         "runtimeseconds",
         "computer",
+        "sensors"
     ]
     for key in keys:
         try:
@@ -59,7 +60,7 @@ def check_yaml(yml):
 
     if yml["benchmark"] == "odometry":
         try:
-            sensors = yml["sensors"]
+            sensors = yml["sensors"].split(", ")
             for sensor in sensors:
                 if sensor not in ["camera", "lidar", "radar", "IMU"]:
                     print("incorrect list of sensors: {}".format(yml["sensors"]))


### PR DESCRIPTION
Minor fix of submission checker tested by running:
```
python3 submission_checker.py
```
...in a folder containing test-odometry.zip.
The .zip included a set of sequences boreas_<sequence_time>.txt, and metadata.yaml:
```
benchmark: odometry
methodname: methodname
email: dla.adolfsson@gmail.com
2d: True
author: Daniel Adolfsson
papertitle: papertitle
paperurl: https://arxiv.org
venue: journal
year: 2024
runtimeseconds: 0.0074
computer: AMD Ryzen 7 7800x3d @ 5.0GHz
sensors: radar
```

Before fix: Exception: metadata.yaml not correctly formatted
After fix: Submission checker PASSED